### PR TITLE
Refactoring: replace TypedDict with dataclass

### DIFF
--- a/backup_scrapbox/__init__.py
+++ b/backup_scrapbox/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from ._env import Env, InvalidEnvError, load_env
 from ._main import backup_scrapbox

--- a/backup_scrapbox/__main__.py
+++ b/backup_scrapbox/__main__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ._main import main
 
 if __name__ == '__main__':

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 import logging
 import pathlib

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -16,17 +16,17 @@ from ._utility import format_timestamp
 def commit(
         env: Env,
         logger: logging.Logger) -> None:
-    git_repository = pathlib.Path(env['git_repository'])
-    backup_directory = pathlib.Path(env['save_directory'])
+    git_repository = pathlib.Path(env.git_repository)
+    backup_directory = pathlib.Path(env.save_directory)
     # check if the git repository exists
     if not is_git_repository(git_repository):
         logger.error('git repository "%s" does not exist', git_repository)
         return
     # switch Git branch
-    if env['git_branch'] is not None:
-        logger.info('switch git branch "%s"', env['git_branch'])
+    if env.git_branch is not None:
+        logger.info('switch git branch "%s"', env.git_branch)
         git_command(
-                ['git', 'switch', env['git_branch']],
+                ['git', 'switch', env.git_branch],
                 git_repository,
                 logger=logger)
     # backup targets
@@ -39,18 +39,18 @@ def commit(
         logger.info('commit %s', format_timestamp(info['timestamp']))
         # clear
         _clear_repository(
-                env['project'],
+                env.project,
                 git_repository,
                 logger)
         # copy
         commit_targets = _copy_backup(
-                env['project'],
+                env.project,
                 git_repository,
                 info['backup_path'],
-                env['page_order'],
+                env.page_order,
                 logger)
         # commit
-        _commit(env['project'],
+        _commit(env.project,
                 git_repository,
                 info,
                 commit_targets,

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 import logging
 import pathlib

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -20,7 +20,7 @@ def download(
     # list
     backup_list: Optional[BackupListJSON] = _request_json(
             f'{_base_url(env)}/list',
-            env['session_id'],
+            env.session_id,
             logger,
             schema=jsonschema_backup_list())
     if backup_list is None:
@@ -37,11 +37,11 @@ def download(
                     max(x['backuped'] for x in backup_list['backups'])))
     time.sleep(request_interval)
     # switch Git branch
-    git_repository = pathlib.Path(env['git_repository'])
-    if env['git_branch'] is not None:
-        logger.info('switch git branch "%s"', env['git_branch'])
+    git_repository = pathlib.Path(env.git_repository)
+    if env.git_branch is not None:
+        logger.info('switch git branch "%s"', env.git_branch)
         git_command(
-                ['git', 'switch', env['git_branch']],
+                ['git', 'switch', env.git_branch],
                 git_repository,
                 logger=logger)
     # get the latest backup timestamp from the Git repository
@@ -63,7 +63,7 @@ def download(
 
 
 def _base_url(env: Env) -> str:
-    return f'https://scrapbox.io/api/project-backup/{env["project"]}'
+    return f'https://scrapbox.io/api/project-backup/{env.project}'
 
 
 def _download_backup(
@@ -74,7 +74,7 @@ def _download_backup(
     # timestamp
     timestamp = info['backuped']
     # path
-    save_directory = pathlib.Path(env['save_directory'])
+    save_directory = pathlib.Path(env.save_directory)
     backup_path = save_directory.joinpath(f'{timestamp}.json')
     info_path = save_directory.joinpath(f'{timestamp}.info.json')
     if backup_path.exists() and info_path.exists():
@@ -89,7 +89,7 @@ def _download_backup(
     url = f'{_base_url(env)}/{info["id"]}.json'
     backup: Optional[BackupJSON] = _request_json(
             url,
-            env['session_id'],
+            env.session_id,
             logger,
             schema=jsonschema_backup())
     time.sleep(request_interval)

--- a/backup_scrapbox/_env.py
+++ b/backup_scrapbox/_env.py
@@ -1,5 +1,7 @@
+import dataclasses
 import logging
-from typing import Final, Literal, Optional, TypedDict, cast
+from typing import Final, Literal, Optional
+import dacite
 import dotenv
 
 
@@ -11,13 +13,14 @@ _PAGE_ORDERS: Final[list[Optional[str]]] = [
         'created-desc']
 
 
-class Env(TypedDict):
+@dataclasses.dataclass
+class Env:
     project: str
     session_id: str
     save_directory: str
     git_repository: str
-    git_branch: Optional[str]
-    page_order: Optional[PageOrder]
+    git_branch: Optional[str] = None
+    page_order: Optional[PageOrder] = None
 
 
 _REQUIRED_KEYS: Final[list[str]] = [
@@ -50,7 +53,7 @@ def load_env(
     logger.debug('env: %s', env)
     # validate
     validate_env(env)
-    return cast(Env, env)
+    return dacite.from_dict(data_class=Env, data=env)
 
 
 def validate_env(env: dict[str, Optional[str]]) -> None:

--- a/backup_scrapbox/_env.py
+++ b/backup_scrapbox/_env.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 from typing import Final, Literal, Optional, TypedDict, cast
 import dotenv

--- a/backup_scrapbox/_env.py
+++ b/backup_scrapbox/_env.py
@@ -1,16 +1,11 @@
 import dataclasses
 import logging
-from typing import Final, Literal, Optional
+from typing import Final, Literal, Optional, get_args
 import dacite
 import dotenv
 
 
 PageOrder = Literal['as-is', 'created-asc', 'created-desc']
-_PAGE_ORDERS: Final[list[Optional[str]]] = [
-        None,
-        'as-is',
-        'created-asc',
-        'created-desc']
 
 
 @dataclasses.dataclass
@@ -72,8 +67,9 @@ def validate_env(env: dict[str, Optional[str]]) -> None:
             messages.append(f'"{key}" is not None or string\n')
     # page order
     if 'page_order' in env:
-        if env['page_order'] not in _PAGE_ORDERS:
+        page_orders = [None, *get_args(PageOrder)]
+        if env['page_order'] not in page_orders:
             messages.append('"page_order" is not {0}\n'.format(
-                    ' / '.join(repr(x) for x in _PAGE_ORDERS)))
+                    ' / '.join(repr(x) for x in page_orders)))
     if messages:
         raise InvalidEnvError(''.join(messages))

--- a/backup_scrapbox/_git.py
+++ b/backup_scrapbox/_git.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 import logging
 import os

--- a/backup_scrapbox/_json.py
+++ b/backup_scrapbox/_json.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 import pathlib
 from typing import Any, Optional, TypedDict

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -1,5 +1,3 @@
-# -*- config: utf-8 -*-
-
 import argparse
 import logging
 import sys

--- a/backup_scrapbox/_utility.py
+++ b/backup_scrapbox/_utility.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 from typing import Optional
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,17 @@ python-versions = ">=3.5.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "dacite"
+version = "1.6.0"
+description = "Simple creation of data classes from dictionaries."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pytest (>=5)", "pytest-cov", "coveralls", "black", "mypy", "pylint"]
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -117,7 +128,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "0b09793960652787b173dd534bc5181a03acf12fecac73bf1a5e9a6db115831d"
+content-hash = "1df2dc4d44112e723cb201a74692b0062b18674cdc1edbe15a6907082e067e72"
 
 [metadata.files]
 attrs = [
@@ -131,6 +142,10 @@ certifi = [
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+dacite = [
+    {file = "dacite-1.6.0-py3-none-any.whl", hash = "sha256:4331535f7aabb505c732fa4c3c094313fc0a1d5ea19907bf4726a7819a68b93f"},
+    {file = "dacite-1.6.0.tar.gz", hash = "sha256:d48125ed0a0352d3de9f493bf980038088f45f3f9d7498f090b50a847daaa6df"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = ""
 
 [tool.poetry.dependencies]
 python = "^3.9"
+dacite = "^1.6.0"
 jsonschema = "^3.2.0"
 python-dotenv = "^0.19.0"
 requests = "^2.26.0"


### PR DESCRIPTION
# Replace typing.TypedDict with dataclasses.dataclass

Replaced Classes: Env, _Backup

JSON type is not replaced with dataclass

- The JSON property names are lowerCamelCase
  - PyLint warns the field names are not snake_case
- The order of fields is changed by the conversion of dataclass and dict
  - In Python, fields must be defined in the order from "no default value" to "with default value"

# Delete Encoding Declaration

Delete endocing declaration (`# -*- encoding: utf-8 -*-`) from '*.py'