### PR TITLE
Refactoring: class Git

### DIFF
--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -5,35 +5,30 @@ import pathlib
 import re
 from typing import Optional, Union
 from ._env import Env, PageOrder
+from ._git import Git
 from ._json import (
         BackupJSON, BackupInfoJSON, jsonschema_backup, jsonschema_backup_info,
         load_json, save_json)
-from ._git import (
-        git_command, git_commit, git_ls_files, git_show_latest_timestamp,
-        is_git_repository)
 from ._utility import format_timestamp
 
 
 def commit(
         env: Env,
         logger: logging.Logger) -> None:
-    git_repository = pathlib.Path(env.git_repository)
+    git = env.git(logger=logger)
     backup_directory = pathlib.Path(env.save_directory)
     # check if the git repository exists
-    if not is_git_repository(git_repository):
-        logger.error('git repository "%s" does not exist', git_repository)
+    if not git.exists():
+        logger.error('git repository "%s" does not exist', git.path)
         return
     # switch Git branch
     if env.git_branch is not None:
         logger.info('switch git branch "%s"', env.git_branch)
-        git_command(
-                ['git', 'switch', env.git_branch],
-                git_repository,
-                logger=logger)
+        git.command(['git', 'switch', env.git_branch])
     # backup targets
     backup_targets = _backup_targets(
             backup_directory,
-            git_repository,
+            git,
             logger)
     # commit
     for info in backup_targets:
@@ -41,21 +36,20 @@ def commit(
         # clear
         _clear_repository(
                 env.project,
-                git_repository,
+                git,
                 logger)
         # copy
         commit_targets = _copy_backup(
                 env.project,
-                git_repository,
+                git,
                 info.backup_path,
                 env.page_order,
                 logger)
         # commit
         _commit(env.project,
-                git_repository,
+                git,
                 info,
-                commit_targets,
-                logger)
+                commit_targets)
 
 
 @dataclasses.dataclass
@@ -67,12 +61,10 @@ class _Backup:
 
 def _backup_targets(
         directory: pathlib.Path,
-        git_repository: pathlib.Path,
+        git: Git,
         logger: logging.Logger) -> list[_Backup]:
     # get latest backup timestamp
-    latest_timestamp = git_show_latest_timestamp(
-            git_repository,
-            logger=logger)
+    latest_timestamp = git.latest_commit_timestamp()
     logger.info('latest backup: %s', format_timestamp(latest_timestamp))
     # find backup
     targets: list[_Backup] = []
@@ -104,11 +96,11 @@ def _backup_targets(
 
 def _clear_repository(
         project: str,
-        git_repository: pathlib.Path,
+        git: Git,
         logger: logging.Logger) -> None:
     targets: list[pathlib.Path] = []
     # load previous backup
-    previous_backup_path = git_repository.joinpath(
+    previous_backup_path = git.path.joinpath(
             f'{_escape_filename(project)}.json')
     logger.debug('load previous backup "%s"', previous_backup_path)
     previous_backup: Optional[BackupJSON] = load_json(
@@ -119,20 +111,17 @@ def _clear_repository(
         return
     targets.append(previous_backup_path)
     # pages/
-    page_directory = git_repository.joinpath('pages')
+    page_directory = git.path.joinpath('pages')
     targets.extend(
             page_directory.joinpath(f'{_escape_filename(page["title"])}.json')
             for page in previous_backup['pages'])
     # git ls-files
-    staged = git_ls_files(git_repository, logger=logger)
+    staged = git.ls_files()
     # rm / git rm
     for target in targets:
         if target.exists():
             if target in staged:
-                git_command(
-                        ['git', 'rm', target.as_posix()],
-                        git_repository,
-                        logger=logger)
+                git.command(['git', 'rm', target.as_posix()])
             else:
                 logger.debug('rm %s', target)
                 target.unlink()
@@ -143,7 +132,7 @@ def _clear_repository(
 
 def _copy_backup(
         project: str,
-        git_repository: pathlib.Path,
+        git: Git,
         backup_path: pathlib.Path,
         page_order: Optional[PageOrder],
         logger: logging.Logger) -> list[pathlib.Path]:
@@ -159,14 +148,14 @@ def _copy_backup(
             "copy backup created at %s",
             format_timestamp(backup['exported']))
     # copy: ${project}.json
-    backup_path = git_repository.joinpath(f'{_escape_filename(project)}.json')
+    backup_path = git.path.joinpath(f'{_escape_filename(project)}.json')
     logger.debug('save "%s"', backup_path)
     save_json(
-            git_repository.joinpath(f'{_escape_filename(project)}.json'),
+            git.path.joinpath(f'{_escape_filename(project)}.json'),
             backup)
     copied.append(backup_path)
     # copy: page/${title}.json
-    page_directory = git_repository.joinpath('pages')
+    page_directory = git.path.joinpath('pages')
     for page in backup['pages']:
         page_path = page_directory.joinpath(
                 f'{_escape_filename(page["title"])}.json')
@@ -178,14 +167,12 @@ def _copy_backup(
 
 def _commit(
         project: str,
-        git_repository: pathlib.Path,
+        git: Git,
         backup: _Backup,
-        targets: list[pathlib.Path],
-        logger: logging.Logger) -> None:
+        targets: list[pathlib.Path]) -> None:
     # git add
     for target in targets:
-        command = ['git', 'add', target.as_posix()]
-        git_command(command, git_repository, logger=logger)
+        git.command(['git', 'add', target.as_posix()])
     # commit message
     message: list[str] = []
     message.append('{0} {1}'.format(
@@ -201,11 +188,9 @@ def _commit(
                     f'{repr(key)}: {repr(value)}'
                     for key, value in info.items())
     # commit
-    git_commit(
-            git_repository,
+    git.commit(
             '\n'.join(message),
-            timestamp=backup.timestamp,
-            logger=logger)
+            timestamp=backup.timestamp)
 
 
 def _sort_pages(

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -24,7 +24,7 @@ def commit(
     # switch Git branch
     if env.git_branch is not None:
         logger.info('switch git branch "%s"', env.git_branch)
-        git.command(['git', 'switch', env.git_branch])
+        git.execute(['git', 'switch', env.git_branch])
     # backup targets
     backup_targets = _backup_targets(
             backup_directory,
@@ -121,7 +121,7 @@ def _clear_repository(
     for target in targets:
         if target.exists():
             if target in staged:
-                git.command(['git', 'rm', target.as_posix()])
+                git.execute(['git', 'rm', target.as_posix()])
             else:
                 logger.debug('rm %s', target)
                 target.unlink()
@@ -172,7 +172,7 @@ def _commit(
         targets: list[pathlib.Path]) -> None:
     # git add
     for target in targets:
-        git.command(['git', 'add', target.as_posix()])
+        git.execute(['git', 'add', target.as_posix()])
     # commit message
     message: list[str] = []
     message.append('{0} {1}'.format(

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -21,10 +21,6 @@ def commit(
     if not git.exists():
         logger.error('git repository "%s" does not exist', git.path)
         return
-    # switch Git branch
-    if env.git_branch is not None:
-        logger.info('switch git branch "%s"', env.git_branch)
-        git.execute(['git', 'switch', env.git_branch])
     # backup targets
     backup_targets = _backup_targets(
             backup_directory,

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -39,7 +39,7 @@ def download(
     # switch Git branch
     if env.git_branch is not None:
         logger.info('switch git branch "%s"', env.git_branch)
-        git.command(['git', 'switch', env.git_branch])
+        git.execute(['git', 'switch', env.git_branch])
     # get the latest backup timestamp from the Git repository
     latest_timestamp = git.latest_commit_timestamp()
     logger.info('latest backup: %s', format_timestamp(latest_timestamp))

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -36,10 +36,6 @@ def download(
             format_timestamp(
                     max(x['backuped'] for x in backup_list['backups'])))
     time.sleep(request_interval)
-    # switch Git branch
-    if env.git_branch is not None:
-        logger.info('switch git branch "%s"', env.git_branch)
-        git.execute(['git', 'switch', env.git_branch])
     # get the latest backup timestamp from the Git repository
     latest_timestamp = git.latest_commit_timestamp()
     logger.info('latest backup: %s', format_timestamp(latest_timestamp))

--- a/backup_scrapbox/_env.py
+++ b/backup_scrapbox/_env.py
@@ -1,8 +1,10 @@
 import dataclasses
 import logging
+import pathlib
 from typing import Final, Literal, Optional, get_args
 import dacite
 import dotenv
+from ._git import Git
 
 
 PageOrder = Literal['as-is', 'created-asc', 'created-desc']
@@ -16,6 +18,15 @@ class Env:
     git_repository: str
     git_branch: Optional[str] = None
     page_order: Optional[PageOrder] = None
+
+    def git(
+            self,
+            *,
+            logger: Optional[logging.Logger] = None) -> Git:
+        return Git(
+                pathlib.Path(self.git_repository),
+                branch=self.git_branch,
+                logger=logger)
 
 
 _REQUIRED_KEYS: Final[list[str]] = [

--- a/backup_scrapbox/_git.py
+++ b/backup_scrapbox/_git.py
@@ -6,6 +6,25 @@ import subprocess
 from typing import Optional
 
 
+class Git:
+    def __init__(
+            self,
+            path: pathlib.Path,
+            *,
+            branch: Optional[str] = None,
+            logger: Optional[logging.Logger] = None) -> None:
+        self._path = path
+        self._branch = branch
+        self._logger = logger or logging.getLogger(__name__)
+
+    @property
+    def path(self) -> pathlib.Path:
+        return self._path
+
+    def exists(self) -> bool:
+        return self.path.is_dir() and self.path.joinpath('.git').is_dir()
+
+
 def is_git_repository(
         path: pathlib.Path) -> bool:
     return path.is_dir() and path.joinpath('.git').exists()

--- a/backup_scrapbox/_git.py
+++ b/backup_scrapbox/_git.py
@@ -24,7 +24,7 @@ class Git:
     def exists(self) -> bool:
         return self.path.is_dir() and self.path.joinpath('.git').is_dir()
 
-    def command(
+    def execute(
             self,
             command: list[str],
             *,
@@ -34,15 +34,14 @@ class Git:
         # check if the repository exists
         if not self.exists():
             self._logger.error('git repository "%s" does not exist', self.path)
-        return _git_command(
+        return _execute_git_command(
                 command,
                 self.path,
                 logger=self._logger,
                 env=env)
 
     def ls_files(self) -> list[pathlib.Path]:
-        command = ['git', 'ls-files', '-z']
-        process = self.command(command)
+        process = self.execute(['git', 'ls-files', '-z'])
         return [self.path.joinpath(path)
                 for path in process.stdout.split('\0')
                 if path]
@@ -63,7 +62,7 @@ class Git:
             commit_time = datetime.datetime.fromtimestamp(timestamp)
             env['GIT_AUTHOR_DATE'] = commit_time.isoformat()
             env['GIT_COMMITTER_DATE'] = commit_time.isoformat()
-        self.command(command, env=env if env else None)
+        self.execute(command, env=env if env else None)
 
     def latest_commit_timestamp(self) -> Optional[int]:
         # check if the repository exists
@@ -73,15 +72,14 @@ class Git:
                     self.path)
             return None
         # git show -s --format=%ct
-        command = ['git', 'show', '-s', '--format=%ct']
-        process = self.command(command)
+        process = self.execute(['git', 'show', '-s', '--format=%ct'])
         timestamp = process.stdout.rstrip('\n')
         if timestamp.isdigit():
             return int(timestamp)
         return None
 
 
-def _git_command(
+def _execute_git_command(
         command: list[str],
         repository: pathlib.Path,
         *,

--- a/backup_scrapbox/_git.py
+++ b/backup_scrapbox/_git.py
@@ -34,6 +34,21 @@ class Git:
         # check if the repository exists
         if not self.exists():
             self._logger.error('git repository "%s" does not exist', self.path)
+        # switch branch
+        if self._branch is not None:
+            branch = _execute_git_command(
+                    ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                    self.path,
+                    logger=self._logger).stdout.rstrip('\n')
+            if branch != self._branch:
+                self._logger.info(
+                        'switch git branch from "%s" to "%s"',
+                        branch,
+                        self._branch)
+                _execute_git_command(
+                        ['git', 'switch', self._branch],
+                        self.path,
+                        logger=self._logger)
         return _execute_git_command(
                 command,
                 self.path,


### PR DESCRIPTION
# Add class Git

In order to switch branches before executing the command, the repository path and a branch are grouped as a class Git.