### PR TITLE
Clean External Link Log Files

### DIFF
--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 import pathlib
-from typing import Any, Optional, get_args
+from typing import Any, Literal, Optional, get_args
 import dacite
 import jsonschema
 import toml
@@ -77,6 +77,7 @@ class ExternalLinkConfig:
     content_types: list[str] = dataclasses.field(default_factory=list)
     excluded_urls: list[str] = dataclasses.field(default_factory=list)
     allways_request_all_links: bool = False
+    keep_logs: int | Literal['all'] = 'all'
 
 
 def jsonschema_external_link_config() -> dict[str, Any]:
@@ -119,6 +120,12 @@ def jsonschema_external_link_config() -> dict[str, Any]:
                 'items': {'type': 'string'},
             },
             'allways_request_all_links': {'type': 'boolean'},
+            'keep_logs': {
+                'oneOf': [
+                    {'type': 'integer', 'minimum': 0},
+                    {'type': 'string', 'enum': ['all']},
+                ],
+            },
         },
     }
     return schema

--- a/backup_scrapbox/_external_link.py
+++ b/backup_scrapbox/_external_link.py
@@ -191,6 +191,9 @@ def save_external_links(
         log_directory.save(backup.timestamp, logs)
     # save list.json
     _save_saved_list(save_directory, config.content_types, logs, logger)
+    # clean logs
+    if config.keep_logs != 'all':
+        log_directory.clean(config.keep_logs)
     # commit target
     return _commit_target(
             save_directory,
@@ -330,6 +333,18 @@ class _LogsDirectory:
                 path,
                 [dataclasses.asdict(log) for log in logs],
                 schema=jsonschema_external_link_logs())
+
+    def clean(
+            self,
+            keep: int) -> None:
+        if keep >= 0:
+            targets = list(reversed(self.find_all()))[keep:]
+            self._logger.info(f'clean {len(targets)} log files')
+            for target in targets:
+                self._logger.info(f'delete log file: {target.path.as_posix()}')
+                target.path.unlink()
+        else:
+            self._logger.warning(f'skip clean: keep({keep}) must be >= 0')
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Add `ExternalLinkConfig.keep_logs: int | Literal['all'] = 'all'`
Add `_LogsDirectory.clean(keep: int) -> None`