### PR TITLE
Option

### DIFF
--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -14,6 +14,7 @@ class ScrapboxConfig:
     project: str
     session_id: str
     save_directory: str
+    request_interval: float = 3.0
 
 
 def jsonschema_scrapbox_config() -> dict[str, Any]:
@@ -25,6 +26,10 @@ def jsonschema_scrapbox_config() -> dict[str, Any]:
             'project': {'type': 'string'},
             'session_id': {'type': 'string'},
             'save_directory': {'type': 'string'},
+            'request_interval': {
+                'type': 'number',
+                'exclusiveMinimum': 0.0,
+            },
         },
     }
     return schema

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -35,20 +35,19 @@ def jsonschema_backup_list() -> dict[str, Any]:
 def download_backups(
         config: Config,
         *,
-        logger: Optional[logging.Logger] = None,
-        request_interval: float = 3.0) -> None:
+        logger: Optional[logging.Logger] = None) -> None:
     logger = logger or logging.getLogger(__name__)
     with _session(config) as session:
         # list
         backup_list = _request_backup_list(config, session, logger)
-        time.sleep(request_interval)
+        time.sleep(config.scrapbox.request_interval)
         if not backup_list:
             return
         # backup
         for info in filter(_backup_filter(config, logger), backup_list):
             # download
             _download_backup(config, session, info, logger)
-            time.sleep(request_interval)
+            time.sleep(config.scrapbox.request_interval)
 
 
 def _base_url(config: Config) -> str:

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -34,10 +34,7 @@ def backup_scrapbox(
     # download backup
     if option.target in (None, 'download'):
         logger.info('target: download')
-        download_backups(
-                config,
-                logger=logger,
-                request_interval=option.request_interval)
+        download_backups(config, logger=logger)
     # commit
     if option.target in (None, 'commit'):
         logger.info('target: commit')
@@ -56,13 +53,11 @@ def _argument_parser() -> argparse.ArgumentParser:
             help='default: download & commit')
     # default: download & commit
     _add_common_arguments(parser)
-    _add_download_arguments(parser)
     # download
     download_parser = sub_parsers.add_parser(
             'download',
             help='download backup from scrapbox.io')
     _add_common_arguments(download_parser)
-    _add_download_arguments(download_parser)
     # commit
     commit_parser = sub_parsers.add_parser(
             'commit',
@@ -92,17 +87,6 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
             dest='verbose',
             action='store_true',
             help='set log level to debug')
-
-
-def _add_download_arguments(parser: argparse.ArgumentParser) -> None:
-    # request interval
-    parser.add_argument(
-            '--request-interval',
-            dest='request_interval',
-            type=float,
-            default=3.0,
-            metavar='SECONDS',
-            help='request interval seconds (default %(default)s)')
 
 
 def _add_export_arguments(parser: argparse.ArgumentParser) -> None:

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -46,7 +46,7 @@ def backup_scrapbox(
 
 
 def _argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog=__package__)
     _add_common_arguments(parser)
     # sub parser
     sub_parsers = parser.add_subparsers(

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -32,16 +32,16 @@ def backup_scrapbox(
     # main
     logger.info('backup-scrapbox')
     # download backup
-    if option.target in (None, 'download'):
-        logger.info('target: download')
+    if option.command in (None, 'download'):
+        logger.info('command: download')
         download_backups(config, logger=logger)
     # commit
-    if option.target in (None, 'commit'):
-        logger.info('target: commit')
+    if option.command in (None, 'commit'):
+        logger.info('command: commit')
         commit_backups(config, logger=logger)
     # export
-    if option.target == 'export':
-        logger.info('target: export')
+    if option.command == 'export':
+        logger.info('command: export')
         export_backups(config, option.destination, logger=logger)
 
 
@@ -50,7 +50,7 @@ def _argument_parser() -> argparse.ArgumentParser:
     _add_common_arguments(parser)
     # sub parser
     sub_parsers = parser.add_subparsers(
-            dest='target',
+            dest='command',
             title='command',
             description=(
                     'command to be executed '

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -47,27 +47,23 @@ def backup_scrapbox(
 
 def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
+    _add_common_arguments(parser)
     # sub parser
     sub_parsers = parser.add_subparsers(
             dest='target',
             help='default: download & commit')
-    # default: download & commit
-    _add_common_arguments(parser)
     # download
-    download_parser = sub_parsers.add_parser(
+    sub_parsers.add_parser(
             'download',
             help='download backup from scrapbox.io')
-    _add_common_arguments(download_parser)
     # commit
-    commit_parser = sub_parsers.add_parser(
+    sub_parsers.add_parser(
             'commit',
             help='commit to Git repository')
-    _add_common_arguments(commit_parser)
     # export
     export_parser = sub_parsers.add_parser(
             'export',
             help='export backups from Git repository')
-    _add_common_arguments(export_parser)
     _add_export_arguments(export_parser)
     return parser
 

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -51,7 +51,10 @@ def _argument_parser() -> argparse.ArgumentParser:
     # sub parser
     sub_parsers = parser.add_subparsers(
             dest='target',
-            help='default: download & commit')
+            title='command',
+            description=(
+                    'command to be executed '
+                    '(if not specified, download and commit are executed)'))
     # download
     sub_parsers.add_parser(
             'download',


### PR DESCRIPTION
# Fix duplicate parsing of common options

## Issue

If the command is specified, common options before the command are ignored.

`python -m backup_scrapbox commit -v`
=> `option.verbose` is `True`

`python -m backup_scrapbox -v commit`
=> `option.verbose` is `False`

## Fixes

Move `--request-interval` in download options to ScrapboxConfig.
- To avoid having options when default command (download + commit).

Delete common options from sub parsers.

# Modify Options

set `prog` to the parser.
Set `title` and `description` to sup parsers.
Rename from `option.target` to `option.command`.