### PR TITLE
Request Timeout

### DIFF
--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -16,6 +16,7 @@ class ScrapboxConfig:
     session_id: str
     save_directory: str
     request_interval: float = 3.0
+    request_timeout: float = 10.0
 
 
 def jsonschema_scrapbox_config() -> dict[str, Any]:
@@ -28,6 +29,10 @@ def jsonschema_scrapbox_config() -> dict[str, Any]:
             'session_id': {'type': 'string'},
             'save_directory': {'type': 'string'},
             'request_interval': {
+                'type': 'number',
+                'exclusiveMinimum': 0.0,
+            },
+            'request_timeout': {
                 'type': 'number',
                 'exclusiveMinimum': 0.0,
             },

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -71,6 +71,7 @@ def _request_backup_list(
     response: Optional[BackupListJSON] = request_json(
             f'{_base_url(config)}/list',
             session=session,
+            timeout=config.scrapbox.request_timeout,
             schema=jsonschema_backup_list(),
             logger=logger)
     # failed to request
@@ -132,6 +133,7 @@ def _download_backup(
     backup: Optional[BackupJSON] = request_json(
             url,
             session=session,
+            timeout=config.scrapbox.request_timeout,
             schema=jsonschema_backup(),
             logger=logger)
     if backup is None:

--- a/backup_scrapbox/_json.py
+++ b/backup_scrapbox/_json.py
@@ -76,13 +76,14 @@ def request_json(
         url: str,
         *,
         session: Optional[requests.Session] = None,
+        timeout: Optional[float] = None,
         schema: Optional[dict] = None,
         logger: Optional[logging.Logger] = None) -> Optional[Any]:
     logger = logger or logging.getLogger(__name__)
     # request
     logger.info(f'get request: {url}')
     with with_session(session) as session_:
-        response = session_.get(url)
+        response = session_.get(url, timeout=timeout)
         if not response.ok:
             logger.error(f'failed to get request "{url}"')
             return None


### PR DESCRIPTION
# Set Timeout to requests.Session.get()

To fix Pylint warning (missing-timeout W3101).

Add `scrapbox.request_timeout` to config.toml.