### PR TITLE
Optimize Git Commit

### DIFF
--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -422,23 +422,6 @@ class BackupJSONs:
                 self.info_path,
                 schema=jsonschema_backup_info())
 
-    def load(
-            self,
-            project: str,
-            directory: pathlib.Path,
-            *,
-            page_order: Optional[PageOrder] = None) -> Optional[Backup]:
-        backup = self.load_backup()
-        info = self.load_info()
-        if backup is None:
-            return None
-        return Backup(
-                project,
-                directory,
-                backup,
-                info,
-                page_order=page_order)
-
 
 class BackupStorage:
     def __init__(self, directory: pathlib.Path) -> None:

--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -322,7 +322,7 @@ class Backup:
 
 
 @dataclasses.dataclass
-class DownloadedBackup:
+class BackupJSONs:
     timestamp: int
     backup_path: pathlib.Path
     info_path: Optional[pathlib.Path]
@@ -367,8 +367,8 @@ class BackupStorage:
     def exists(self, timestamp: int) -> bool:
         return self.backup_path(timestamp).exists()
 
-    def backups(self) -> list[DownloadedBackup]:
-        backups: list[DownloadedBackup] = []
+    def backups(self) -> list[BackupJSONs]:
+        backups: list[BackupJSONs] = []
         for path in self._directory.iterdir():
             # check if the path is file
             if not path.is_file():
@@ -382,7 +382,7 @@ class BackupStorage:
             timestamp = int(filename_match.group('timestamp'))
             # info path
             info_path = self.info_path(timestamp)
-            backups.append(DownloadedBackup(
+            backups.append(BackupJSONs(
                     timestamp=timestamp,
                     backup_path=path,
                     info_path=info_path if info_path.exists() else None))

--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import dataclasses
+import itertools
 import logging
 import pathlib
 import re
@@ -399,6 +400,20 @@ def _sort_pages(
             pages.sort(key=lambda page: page['created'])
         case 'created-desc':
             pages.sort(key=lambda page: - page['created'])
+
+
+def _is_sorted_pages(
+        pages: list[BackupPageJSON],
+        order: Optional[PageOrder]) -> Optional[bool]:
+    if order is None or order == 'as-is':
+        return None
+    # sort shallow copied pages
+    sorted_pages = pages[:]
+    _sort_pages(sorted_pages, order)
+    # compare the id of each page
+    return all(
+            id(x) == id(y)
+            for x, y in itertools.zip_longest(pages, sorted_pages))
 
 
 def _escape_filename(text: str) -> str:

--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -255,13 +255,7 @@ class Backup:
     def sort_pages(
             self,
             order: Optional[PageOrder] = None) -> None:
-        match order:
-            case None | 'as-is':
-                pass
-            case 'created-asc':
-                self._backup['pages'].sort(key=lambda page: page['created'])
-            case 'created-desc':
-                self._backup['pages'].sort(key=lambda page: - page['created'])
+        _sort_pages(self._backup['pages'], order)
 
     def save_files(self) -> list[pathlib.Path]:
         files: list[pathlib.Path] = []
@@ -393,6 +387,18 @@ class BackupStorage:
                     info_path=info_path if info_path.exists() else None))
         # sort by old...new
         return sorted(backups, key=lambda backup: backup.timestamp)
+
+
+def _sort_pages(
+        pages: list[BackupPageJSON],
+        order: Optional[PageOrder]) -> None:
+    match order:
+        case None | 'as-is':
+            pass
+        case 'created-asc':
+            pages.sort(key=lambda page: page['created'])
+        case 'created-desc':
+            pages.sort(key=lambda page: - page['created'])
 
 
 def _escape_filename(text: str) -> str:

--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -281,22 +281,22 @@ class Backup:
         backup_path = self.directory.joinpath(
                 f'{_escape_filename(self.project)}.json')
         if backup != self._backup:
-            logger.debug(f'update "{backup_path.as_posix()}"')
+            logger.debug(f'update "{backup_path}"')
             save_json(backup_path, backup)
             updated.append(backup_path)
         # info
         info_path = backup_path.with_suffix('.info.json')
         if info != self._info:
             if info is None:
-                logger.debug(f'remove "{backup_path.as_posix()}"')
+                logger.debug(f'remove "{backup_path}"')
                 info_path.unlink()
                 removed.append(info_path)
             elif self._info is None:
-                logger.debug(f'add "{backup_path.as_posix()}"')
+                logger.debug(f'add "{backup_path}"')
                 save_json(info_path, info)
                 added.append(info_path)
             else:
-                logger.debug(f'update "{backup_path.as_posix()}"')
+                logger.debug(f'update "{backup_path}"')
                 save_json(info_path, info)
                 updated.append(info_path)
         # previous pages
@@ -311,20 +311,20 @@ class Backup:
             if title in previous_pages:
                 if page != previous_pages[title]:
                     # update page
-                    logger.debug(f'update "{page_path.as_posix()}"')
+                    logger.debug(f'update "{page_path}"')
                     save_json(page_path, page)
                     updated.append(page_path)
                 # remove from dict to detect deleted pages
                 del previous_pages[title]
             else:
                 # add new page
-                logger.debug(f'add "{page_path.as_posix()}"')
+                logger.debug(f'add "{page_path}"')
                 save_json(page_path, page)
                 added.append(page_path)
         # remove deleted pages
         for title in previous_pages.keys():
             page_path = page_directory.joinpath(f'{title}.json')
-            logger.debug(f'remove "{page_path.as_posix()}"')
+            logger.debug(f'remove "{page_path}"')
             page_path.unlink()
             removed.append(page_path)
         # update self
@@ -356,19 +356,19 @@ class Backup:
         # {project}.json
         backup_path = self.directory.joinpath(
                 f'{_escape_filename(self.project)}.json')
-        logger.debug(f'save "{backup_path.as_posix()}"')
+        logger.debug(f'save "{backup_path}"')
         save_json(backup_path, self._backup)
         # {project}.info.json
         if self._info is not None:
             info_path = backup_path.with_suffix('.info.json')
-            logger.debug(f'save "{info_path.as_posix()}"')
+            logger.debug(f'save "{info_path}"')
             save_json(info_path, self._info)
         # pages
         page_directory = self.directory.joinpath('pages')
         for page in self._backup['pages']:
             page_path = page_directory.joinpath(
                     f'{_escape_filename(page["title"])}.json')
-            logger.debug(f'save "{page_path.as_posix()}"')
+            logger.debug(f'save "{page_path}"')
             save_json(page_path, page)
 
     @classmethod

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import pathlib
 from typing import Optional
-from ._backup import Backup, BackupStorage, DownloadedBackup
+from ._backup import Backup, BackupJSONs, BackupStorage
 from ._config import Config, GitEmptyInitialCommitConfig
 from ._external_link import save_external_links
 from ._git import Commit, CommitTarget, Git
@@ -74,7 +74,7 @@ def commit_backup(
 def _backup_targets(
         storage: BackupStorage,
         git: Git,
-        logger: logging.Logger) -> list[DownloadedBackup]:
+        logger: logging.Logger) -> list[BackupJSONs]:
     # get latest backup timestamp
     latest = git.latest_commit_timestamp()
     logger.info(f'latest backup: {format_timestamp(latest)}')

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -17,63 +17,65 @@ def commit_backups(
     logger = logger or logging.getLogger(__name__)
     git = config.git.git(logger=logger)
     storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory))
+    backup: Optional[Backup] = None
+    # git switch
+    if git.exists():
+        git.switch(allow_orphan=True)
     # backup targets
     backup_targets = _backup_targets(storage, git, logger)
     # commit
     for target in backup_targets:
         logger.info(f'commit {format_timestamp(target.timestamp)}')
-        # load backup
-        backup = target.load(
-                config.scrapbox.project,
-                git.path,
-                page_order=config.git.page_order)
+        # load backup repository
         if backup is None:
-            logger.info(
-                    'failed to load backup'
-                    f' {format_timestamp(target.timestamp)}')
-            continue
+            backup = Backup.load(
+                    config.scrapbox.project,
+                    git.path,
+                    page_order=config.git.page_order,
+                    logger=logger)
         # commit
-        commit_backup(config, backup, logger=logger)
+        commit_backup(
+                config,
+                target,
+                backup=backup,
+                logger=logger)
 
 
 def commit_backup(
         config: Config,
-        backup: Backup,
+        data: BackupJSONs,
         *,
+        backup: Optional[Backup] = None,
         logger: Optional[logging.Logger] = None) -> None:
     logger = logger or logging.getLogger(__name__)
     git = config.git.git(logger=logger)
     # git init
     if not git.exists():
-        logger.info('create git repository "{git.path}"')
+        logger.info(f'create git repository "{git.path}"')
         git.init()
+    # git switch
+    git.switch(allow_orphan=True)
     # initial commit
-    _initial_commit(config, git, [backup])
-    # load previous backup
-    previous_backup = Backup.load(
-            backup.project,
-            git.path,
-            page_order=config.git.page_order,
+    _initial_commit(config, git, [data])
+    # staging
+    commit_target = staging_backup(
+            config,
+            data,
+            backup=backup,
             logger=logger)
-    # update backup json
-    target = _update_backup_json(backup, previous_backup, logger)
-    # external link
-    if config.external_link.enabled:
-        target.update(save_external_links(
-                backup,
-                git.path,
-                config=config.external_link,
-                logger=logger))
+    if commit_target is None:
+        logger.error('failed to staging')
+        return
     # commit message
     message = Commit.message(
-            backup.project,
-            backup.timestamp,
-            backup.info)
+            config.scrapbox.project,
+            data.timestamp,
+            data.load_info())
     # commit
     git.commit(
-            target,
+            commit_target,
             message,
-            timestamp=backup.timestamp)
+            timestamp=data.timestamp)
 
 
 def staging_backup(
@@ -145,34 +147,10 @@ def _backup_targets(
     return targets
 
 
-def _update_backup_json(
-        backup: Backup,
-        previous_backup: Optional[Backup],
-        logger: logging.Logger) -> CommitTarget:
-    # previous files
-    previous_files = set(
-            previous_backup.save_files()
-            if previous_backup is not None
-            else [])
-    # clear previous files
-    for previous_file in previous_files:
-        logger.debug(f'remove "{previous_file.as_posix()}"')
-        previous_file.unlink()
-    # next files
-    next_files = set(backup.save_files())
-    # copy next files
-    backup.save(logger=logger)
-    # commit target
-    return CommitTarget(
-            added=next_files - previous_files,
-            updated=next_files & previous_files,
-            deleted=previous_files - next_files)
-
-
 def _initial_commit(
         config: Config,
         git: Git,
-        backups: list[Backup]) -> None:
+        backups: list[BackupJSONs]) -> None:
     # empty initial commit is enabled
     if config.git.empty_initial_commit is None:
         return
@@ -191,7 +169,7 @@ def _initial_commit(
 
 def _initial_commit_timestamp(
         config: GitEmptyInitialCommitConfig,
-        backups: list[Backup]) -> int:
+        backups: list[BackupJSONs]) -> int:
     match config.timestamp:
         case datetime.datetime():
             return int(config.timestamp.timestamp())
@@ -210,6 +188,7 @@ def _initial_commit_timestamp(
                     'unable to define timestamp')
             return timestamp
         case 'oldest_created_page':
+            # select oldest data
             backup = min(
                     backups,
                     default=None,
@@ -218,8 +197,15 @@ def _initial_commit_timestamp(
                 raise InitialCommitError(
                     'Since there is no backup, '
                     'unable to define timestamp')
+            # load json
+            backup_data = backup.load_backup()
+            if backup_data is None:
+                raise InitialCommitError(
+                    'Could not load oldest backup'
+                    f' "{backup.backup_path}"')
+            # oldest created page
             timestamp = min(
-                    (page['created'] for page in backup.data['pages']),
+                    (page['created'] for page in backup_data['pages']),
                     default=None)
             if timestamp is None:
                 raise InitialCommitError(

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -23,14 +23,15 @@ def commit_backups(
     for target in backup_targets:
         logger.info(f'commit {format_timestamp(target.timestamp)}')
         # load backup
-        backup = target.load(config.scrapbox.project, git.path)
+        backup = target.load(
+                config.scrapbox.project,
+                git.path,
+                page_order=config.git.page_order)
         if backup is None:
             logger.info(
                     'failed to load backup'
                     f' {format_timestamp(target.timestamp)}')
             continue
-        # sort pages
-        backup.sort_pages(config.git.page_order)
         # commit
         commit_backup(config, backup, logger=logger)
 
@@ -49,7 +50,11 @@ def commit_backup(
     # initial commit
     _initial_commit(config, git, [backup])
     # load previous backup
-    previous_backup = Backup.load(backup.project, git.path)
+    previous_backup = Backup.load(
+            backup.project,
+            git.path,
+            page_order=config.git.page_order,
+            logger=logger)
     # update backup json
     target = _update_backup_json(backup, previous_backup, logger)
     # external link

--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -228,7 +228,7 @@ def load_config(
         logger: Optional[logging.Logger] = None) -> Config:
     logger = logger or logging.getLogger(__name__)
     # load TOML
-    logger.info(f'load config from "{path.as_posix()}"')
+    logger.info(f'load config from "{path}"')
     with path.open(encoding='utf-8') as file:
         loaded = toml.load(file)
     logger.debug(f'loaded toml: {repr(loaded)}')

--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -94,6 +94,7 @@ class GitConfig:
                 branch=self.branch,
                 user_name=self.user_name,
                 user_email=self.user_email,
+                staging_step_size=self.staging_step_size,
                 logger=logger)
 
 

--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -75,6 +75,7 @@ def jsonschema_git_empty_initial_commit_config() -> dict[str, Any]:
 
 @dataclasses.dataclass(frozen=True)
 class GitConfig:
+    # pylint: disable=too-many-instance-attributes
     path: str
     executable: Optional[str] = None
     branch: Optional[str] = None
@@ -82,6 +83,7 @@ class GitConfig:
     user_name: Optional[str] = None
     user_email: Optional[str] = None
     empty_initial_commit: Optional[GitEmptyInitialCommitConfig] = None
+    staging_step_size: int = 1
 
     def git(self,
             *,
@@ -118,6 +120,10 @@ def jsonschema_git_config() -> dict[str, Any]:
             },
             'empty_initial_commit':
                 jsonschema_git_empty_initial_commit_config(),
+            'staging_step_size': {
+                'type': 'integer',
+                'minimum': 1,
+            }
         },
     }
     return schema

--- a/backup_scrapbox/_export.py
+++ b/backup_scrapbox/_export.py
@@ -17,7 +17,7 @@ def export_backups(
     # check if the destination exists
     if not destination.exists():
         logger.error(
-                f'export directory "{destination.as_posix()}" does not exist')
+                f'export directory "{destination}" does not exist')
         return
     # commits
     commits = git.commits()

--- a/backup_scrapbox/_external_link.py
+++ b/backup_scrapbox/_external_link.py
@@ -303,7 +303,7 @@ class _LogsDirectory:
             timestamp: int) -> Optional[list[ExternalLinkLog]]:
         file = self.find(timestamp)
         if file is not None:
-            self._logger.info(f'load logs from "{file.path.as_posix()}"')
+            self._logger.info(f'load logs from "{file.path}"')
             logs = file.load()
             if logs is not None:
                 return logs
@@ -317,7 +317,7 @@ class _LogsDirectory:
         file = self.find_latest(timestamp=timestamp)
         if file is not None:
             self._logger.info(
-                    f'load latest logs from "{file.path.as_posix()}"')
+                    f'load latest logs from "{file.path}"')
             logs = file.load()
             if logs is not None:
                 return logs
@@ -328,7 +328,7 @@ class _LogsDirectory:
             timestamp: int,
             logs: list[ExternalLinkLog]) -> None:
         path = self.file_path(timestamp)
-        self._logger.info(f'save logs to "{path.as_posix()}"')
+        self._logger.info(f'save logs to "{path}"')
         save_json(
                 path,
                 [dataclasses.asdict(log) for log in logs],
@@ -341,7 +341,7 @@ class _LogsDirectory:
             targets = list(reversed(self.find_all()))[keep:]
             self._logger.info(f'clean {len(targets)} log files')
             for target in targets:
-                self._logger.info(f'delete log file: {target.path.as_posix()}')
+                self._logger.info(f'delete log file: {target.path}')
                 target.path.unlink()
         else:
             self._logger.warning(f'skip clean: keep({keep}) must be >= 0')
@@ -504,7 +504,7 @@ async def _request(
                 save_path = config.save_directory.file_path(link.url)
                 logger.debug(
                         f'request({index}):'
-                        f' save to "{save_path.as_posix()}"')
+                        f' save to "{save_path}"')
                 if not save_path.parent.exists():
                     save_path.parent.mkdir(parents=True)
                 with save_path.open(mode='bw') as file:
@@ -553,7 +553,7 @@ def _load_saved_list(
         directory: _SaveDirectory,
         logger: logging.Logger) -> Optional[SavedExternalLinksInfo]:
     file_path = directory.list_path()
-    logger.debug(f'load saved link list from {file_path.as_posix()}')
+    logger.debug(f'load saved link list from {file_path}')
     data = load_json(
             file_path,
             schema=jsonschema_saved_external_links_info())
@@ -571,7 +571,7 @@ def _save_saved_list(
     saved_list = SavedExternalLinksInfo(
             content_types=sorted(content_types),
             urls=sorted(log.url for log in logs if log.is_saved))
-    logger.debug(f'save saved link list to {file_path.as_posix()}')
+    logger.debug(f'save saved link list to {file_path}')
     save_json(
             file_path,
             dataclasses.asdict(saved_list),

--- a/backup_scrapbox/_git.py
+++ b/backup_scrapbox/_git.py
@@ -88,8 +88,7 @@ class CommitTarget:
                 2):
             for path in getattr(self, set1) & getattr(self, set2):
                 errors.append(
-                        f'"{path.as_posix()}" exists'
-                        f' in both "{set1}" and "{set2}"')
+                        f'"{path}" exists in both "{set1}" and "{set2}"')
         # raise error
         if errors:
             raise CommitTargetError(''.join(errors))


### PR DESCRIPTION
# Optimeize Git Commit

## Only update files on updated pages

Add `Backup.update()` to update only files on updated pages.

## Add git.staging_step_size to config.toml

Add stating_step_size to GitConfig for passing multiple files to `git add/rm` at once.

## Defference from Before

Previously, the timestamp was obtained from `BackupJSON['exported']`, but now it is obtained from `BackupInfoJSON['backuped']`.

## Modifications

Add `staging_backup()`.
Rename from `DownloadedBackup` to `BackupJSONs`.
On `Backup.load()`, check if pages are sorted.