### PR TITLE
Subdirectories according to timestamps

### DIFF
--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -440,9 +440,6 @@ class BackupStorage:
     def info_path(self, timestamp: int) -> pathlib.Path:
         return self._directory.joinpath(f'{timestamp}.info.json')
 
-    def exists(self, timestamp: int) -> bool:
-        return self.backup_path(timestamp).exists()
-
     def backups(self) -> list[BackupJSONs]:
         backups: list[BackupJSONs] = []
         for path in self._directory.iterdir():

--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -431,18 +431,22 @@ class BackupJSONs:
 
 
 class BackupStorage:
-    def __init__(self, directory: pathlib.Path) -> None:
-        self._directory = directory
+    def __init__(self, path: pathlib.Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> pathlib.Path:
+        return self._path
 
     def backup_path(self, timestamp: int) -> pathlib.Path:
-        return self._directory.joinpath(f'{timestamp}.json')
+        return self.path.joinpath(f'{timestamp}.json')
 
     def info_path(self, timestamp: int) -> pathlib.Path:
-        return self._directory.joinpath(f'{timestamp}.info.json')
+        return self.path.joinpath(f'{timestamp}.info.json')
 
     def backups(self) -> list[BackupJSONs]:
         backups: list[BackupJSONs] = []
-        for path in self._directory.iterdir():
+        for path in self._path.iterdir():
             # check if the path is file
             if not path.is_file():
                 continue

--- a/backup_scrapbox/_backup.py
+++ b/backup_scrapbox/_backup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import dataclasses
 import itertools
 import logging
+import math
 import pathlib
 import re
 from typing import Any, Generator, Literal, Optional, Tuple, TypedDict
@@ -431,38 +432,37 @@ class BackupJSONs:
 
 
 class BackupStorage:
-    def __init__(self, path: pathlib.Path) -> None:
+    def __init__(
+            self,
+            path: pathlib.Path,
+            *,
+            subdirectory: bool = False) -> None:
         self._path = path
+        self._subdirectory = subdirectory
 
     @property
     def path(self) -> pathlib.Path:
         return self._path
 
     def backup_path(self, timestamp: int) -> pathlib.Path:
-        return self.path.joinpath(f'{timestamp}.json')
+        directory = _backup_directory(
+                self._path,
+                self._subdirectory,
+                timestamp)
+        return directory.joinpath(f'{timestamp}.json')
 
     def info_path(self, timestamp: int) -> pathlib.Path:
-        return self.path.joinpath(f'{timestamp}.info.json')
+        directory = _backup_directory(
+                self._path,
+                self._subdirectory,
+                timestamp)
+        return directory.joinpath(f'{timestamp}.info.json')
 
     def backups(self) -> list[BackupJSONs]:
-        backups: list[BackupJSONs] = []
-        for path in self._path.iterdir():
-            # check if the path is file
-            if not path.is_file():
-                continue
-            # check if the filename is '{timestamp}.json'
-            filename_match = re.match(
-                    r'^(?P<timestamp>\d+)\.json$',
-                    path.name)
-            if filename_match is None:
-                continue
-            timestamp = int(filename_match.group('timestamp'))
-            # info path
-            info_path = self.info_path(timestamp)
-            backups.append(BackupJSONs(
-                    timestamp=timestamp,
-                    backup_path=path,
-                    info_path=info_path if info_path.exists() else None))
+        backups = (
+            _search_subdirectory(self._path)
+            if self._subdirectory
+            else _search_backup(self._path))
         # sort by old...new
         return sorted(backups, key=lambda backup: backup.timestamp)
 
@@ -540,3 +540,54 @@ def _filter_code(
         # code snippets
         line = code_snippets.sub(' ', line)
         yield line, Location(title=title, line=i)
+
+
+def _backup_directory(
+        path: pathlib.Path,
+        subdirectory: bool,
+        timestamp: int) -> pathlib.Path:
+    if subdirectory:
+        return path.joinpath(str(math.floor(timestamp / 1.0e+7)))
+    return path
+
+
+def _search_backup(
+        directory: pathlib.Path) -> list[BackupJSONs]:
+    # search '{timestamp}.json' & '{timestamp}.info.json'
+    backups: list[BackupJSONs] = []
+    # check if the path is directory
+    if directory.is_dir():
+        for path in directory.iterdir():
+            # check if the path is file
+            if not path.is_file():
+                continue
+            # check if the filename is '{timestamp}.json'
+            filename_match = re.match(
+                    r'^(?P<timestamp>\d+)\.json$',
+                    path.name)
+            if filename_match is None:
+                continue
+            timestamp = int(filename_match.group('timestamp'))
+            # info path
+            info_path = directory.joinpath(f'{timestamp}.info.json')
+            backups.append(BackupJSONs(
+                    timestamp=timestamp,
+                    backup_path=path,
+                    info_path=info_path if info_path.exists() else None))
+    return backups
+
+
+def _search_subdirectory(
+        directory: pathlib.Path) -> list[BackupJSONs]:
+    # search directory '{timestamp / 1.0e+7}'
+    backups: list[BackupJSONs] = []
+    # check if the path is directory
+    if directory.is_dir():
+        for path in directory.iterdir():
+            # check if the path is directory
+            if not path.is_dir():
+                continue
+            # check if the directory name is 'timestamp / 1.0e+7'
+            if re.match(r'[0-9]+', path.name):
+                backups.extend(_search_backup(path))
+    return backups

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -149,7 +149,7 @@ def _backup_targets(
             (x for x in [backup_start, latest_commit] if x is not None),
             default=None)
     # find backup
-    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory))
+    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory.name))
     targets = [
             backup for backup in storage.backups()
             if threshold is None or threshold < backup.timestamp]

--- a/backup_scrapbox/_commit.py
+++ b/backup_scrapbox/_commit.py
@@ -1,8 +1,7 @@
 import datetime
 import logging
-import pathlib
 from typing import Optional
-from ._backup import Backup, BackupJSONs, BackupStorage
+from ._backup import Backup, BackupJSONs
 from ._config import Config, GitEmptyInitialCommitConfig
 from ._external_link import save_external_links
 from ._git import Commit, CommitTarget, Git
@@ -149,7 +148,7 @@ def _backup_targets(
             (x for x in [backup_start, latest_commit] if x is not None),
             default=None)
     # find backup
-    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory.name))
+    storage = config.scrapbox.save_directory.storage()
     targets = [
             backup for backup in storage.backups()
             if threshold is None or threshold < backup.timestamp]

--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -18,7 +18,9 @@ class ScrapboxSaveDirectoryConfig:
     subdirectory: bool = False
 
     def storage(self) -> BackupStorage:
-        return BackupStorage(pathlib.Path(self.name))
+        return BackupStorage(
+                pathlib.Path(self.name),
+                subdirectory=self.subdirectory)
 
 
 def jsonschema_scrapbox_save_directory_config() -> dict[str, Any]:

--- a/backup_scrapbox/_config.py
+++ b/backup_scrapbox/_config.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Literal, Optional, get_args
 import dacite
 import jsonschema
 import toml
-from ._backup import PageOrder
+from ._backup import BackupStorage, PageOrder
 from ._git import Git
 
 
@@ -16,6 +16,9 @@ from ._git import Git
 class ScrapboxSaveDirectoryConfig:
     name: str
     subdirectory: bool = False
+
+    def storage(self) -> BackupStorage:
+        return BackupStorage(pathlib.Path(self.name))
 
 
 def jsonschema_scrapbox_save_directory_config() -> dict[str, Any]:

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -106,7 +106,7 @@ def _backup_filter(
     latest_timestamp = git.latest_commit_timestamp()
     logger.info(f'latest backup: {format_timestamp(latest_timestamp)}')
     # backup storage
-    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory))
+    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory.name))
 
     def backup_filter(backup: BackupInfoJSON) -> bool:
         timestamp = backup['backuped']
@@ -149,7 +149,7 @@ def _download_backup(
     if backup is None:
         return
     # save
-    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory))
+    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory.name))
     # save backup
     backup_path = storage.backup_path(timestamp)
     logger.info(f'save "{backup_path}"')

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -1,11 +1,9 @@
 import logging
-import pathlib
 import time
 from typing import Any, Callable, Optional, TypedDict
 import requests
 from ._backup import (
-    BackupJSON, BackupInfoJSON, BackupStorage, jsonschema_backup,
-    jsonschema_backup_info)
+    BackupJSON, BackupInfoJSON, jsonschema_backup, jsonschema_backup_info)
 from ._config import Config
 from ._json import request_json, save_json
 from ._utility import format_timestamp
@@ -106,7 +104,7 @@ def _backup_filter(
     latest_timestamp = git.latest_commit_timestamp()
     logger.info(f'latest backup: {format_timestamp(latest_timestamp)}')
     # backup storage
-    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory.name))
+    storage = config.scrapbox.save_directory.storage()
 
     def backup_filter(backup: BackupInfoJSON) -> bool:
         timestamp = backup['backuped']
@@ -149,7 +147,7 @@ def _download_backup(
     if backup is None:
         return
     # save
-    storage = BackupStorage(pathlib.Path(config.scrapbox.save_directory.name))
+    storage = config.scrapbox.save_directory.storage()
     # save backup
     backup_path = storage.backup_path(timestamp)
     logger.info(f'save "{backup_path}"')

--- a/backup_scrapbox/_download.py
+++ b/backup_scrapbox/_download.py
@@ -108,7 +108,7 @@ def _backup_filter(
 
     def backup_filter(backup: BackupInfoJSON) -> bool:
         timestamp = backup['backuped']
-        if storage.exists(timestamp):
+        if storage.backup_path(timestamp).exists():
             logger.debug(
                     f'skip {format_timestamp(timestamp)}: already downloaded')
             return False

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import pathlib
 from typing import Optional
-from ._config import Config, load_config
+from ._config import Config, ScrapboxSaveDirectoryConfig, load_config
 from ._download import download_backups
 from ._commit import commit_backups
 from ._export import export_backups
@@ -42,7 +42,9 @@ def backup_scrapbox(
     # export
     if option.command == 'export':
         logger.info('command: export')
-        export_backups(config, option.destination, logger=logger)
+        destination = ScrapboxSaveDirectoryConfig(
+                name=option.destination).storage()
+        export_backups(config, destination, logger=logger)
 
 
 def _argument_parser() -> argparse.ArgumentParser:
@@ -93,7 +95,6 @@ def _add_export_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
             '-d', '--destination',
             dest='destination',
-            type=pathlib.Path,
             required=True,
             metavar='DIR',
             help='directory to export backups')

--- a/backup_scrapbox/_main.py
+++ b/backup_scrapbox/_main.py
@@ -43,7 +43,8 @@ def backup_scrapbox(
     if option.command == 'export':
         logger.info('command: export')
         destination = ScrapboxSaveDirectoryConfig(
-                name=option.destination).storage()
+                name=option.destination,
+                subdirectory=option.subdirectory).storage()
         export_backups(config, destination, logger=logger)
 
 
@@ -98,3 +99,9 @@ def _add_export_arguments(parser: argparse.ArgumentParser) -> None:
             required=True,
             metavar='DIR',
             help='directory to export backups')
+    # subdirectory
+    parser.add_argument(
+            '--subdirectory',
+            dest='subdirectory',
+            action='store_true',
+            help='create subdirectories on export')


### PR DESCRIPTION
# Subdirectories according to timestamps

Create subdirectories according to timestamps when saving/exporting JSON files.

The name of the subdirectory is the quotient of the timestamp divided by 1.0e+7.
This causes subdirectories to change every 115.74 days.

# Config

A table can be set for the value of `scrapbox.save_directory`.

```TOML
[scrapbox]
save_directory = {name="...", subdirectory=true}
```

# Export

Add `--subdirectory` option to export command. 