### PR TITLE
Modify save_external_links()

### DIFF
--- a/backup_cosense/_commit.py
+++ b/backup_cosense/_commit.py
@@ -138,7 +138,8 @@ def staging_backup(
     if config.external_link.enabled:
         commit_target.update(
             save_external_links(
-                backup,
+                backup.timestamp,
+                backup.external_links(),
                 git.path,
                 config=config.external_link,
                 logger=logger,

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -8,6 +8,7 @@ import pathlib
 import random
 import re
 import time
+from collections import defaultdict
 from typing import Any, Literal, Optional, Self
 
 import aiohttp
@@ -269,9 +270,53 @@ class _LogFile:
 
 
 @dataclasses.dataclass
+class _LinkLogPair:
+    link: Optional[ExternalLink] = None
+    log: Optional[ExternalLinkLog] = None
+
+
+@dataclasses.dataclass
 class _Log:
     timestamp: int
     logs: list[ExternalLinkLog]
+    added_links: list[ExternalLink] = dataclasses.field(default_factory=list)
+    deleted_links: list[str] = dataclasses.field(default_factory=list)
+
+    def update_links(
+        self,
+        timestamp: int,
+        links: list[ExternalLink],
+    ) -> Self:
+        # match link & log
+        pairs: dict[str, _LinkLogPair] = defaultdict(_LinkLogPair)
+        for link in links:
+            pairs[link.url].link = link
+        for log in self.logs:
+            pairs[log.url].log = log
+        # classify
+        logs: list[ExternalLinkLog] = []
+        added_links: list[ExternalLink] = []
+        deleted_links: list[str] = []
+        for pair in pairs.values():
+            if pair.log is None:
+                if pair.link is None:
+                    pass
+                else:
+                    added_links.append(pair.link)
+            else:
+                if pair.link is None:
+                    deleted_links.append(pair.log.url)
+                else:
+                    # replace locations
+                    log = copy.copy(pair.log)
+                    log.locations = copy.copy(pair.link.locations)
+                    logs.append(log)
+        return self.__class__(
+            timestamp=timestamp,
+            logs=logs,
+            added_links=added_links,
+            deleted_links=deleted_links,
+        )
 
     @classmethod
     def load(cls, path: pathlib.Path, timestamp: int) -> Optional[Self]:
@@ -391,12 +436,6 @@ class _LogDirectory:
                 target.path.unlink()
         else:
             self._logger.warning(f"skip clean: keep({keep}) must be >= 0")
-
-
-@dataclasses.dataclass
-class _LinkLogPair:
-    link: Optional[ExternalLink] = None
-    log: Optional[ExternalLinkLog] = None
 
 
 @dataclasses.dataclass

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -405,8 +405,10 @@ class _LogEditor:
         self,
         timestamp: int,
         logs: list[ExternalLinkLog],
+        logger: logging.Logger,
     ) -> None:
         self._timestamp = timestamp
+        self._logger = logger
         self._logs: dict[str, ExternalLinkLog] = {log.url: log for log in logs}
         self._added_links: dict[str, ExternalLink] = {}
         self._deleted_links: set[str] = set()
@@ -431,7 +433,9 @@ class _LogEditor:
 
     def add_log(self, log: ExternalLinkLog) -> None:
         # delete from added links
-        self._added_links.pop(log.url)
+        link = self._added_links.pop(log.url, None)
+        if link is None:
+            self._logger.warning(f"log of non-target URL({log.url}) is added")
         # add to logs
         self._logs[log.url] = log
 

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -318,6 +318,17 @@ class _Log:
             deleted_links=deleted_links,
         )
 
+    def add_log(self, log: ExternalLinkLog) -> None:
+        # delete from added links
+        link = next(
+            (link for link in self.added_links if log.url == link.url),
+            None,
+        )
+        if link is not None:
+            self.added_links.remove(link)
+        # add to logs
+        self.logs.append(log)
+
     @classmethod
     def load(cls, path: pathlib.Path, timestamp: int) -> Optional[Self]:
         logs = load_json(path, schema=jsonschema_external_link_logs())

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -150,7 +150,7 @@ def save_external_links(
     if session is None:
         session = _create_session(config)
     # log directory
-    log_directory = _LogsDirectory(pathlib.Path(config.log_directory), logger)
+    log_directory = _LogDirectory(pathlib.Path(config.log_directory), logger)
     # links directory
     links_directory = _LinksDirectory(
         git_directory.joinpath(config.save_directory),
@@ -267,7 +267,7 @@ def _request_logs(
 
 
 @dataclasses.dataclass
-class _LogsFile:
+class _LogFile:
     path: pathlib.Path
     timestamp: int
 
@@ -282,7 +282,7 @@ class _LogsFile:
         return f"external_link_{timestamp}.json"
 
 
-class _LogsDirectory:
+class _LogDirectory:
     def __init__(
         self,
         directory: pathlib.Path,
@@ -292,16 +292,16 @@ class _LogsDirectory:
         self._logger = logger
 
     def file_path(self, timestamp: int) -> pathlib.Path:
-        return self._directory.joinpath(_LogsFile.file_name(timestamp))
+        return self._directory.joinpath(_LogFile.file_name(timestamp))
 
-    def find(self, timestamp: int) -> Optional[_LogsFile]:
+    def find(self, timestamp: int) -> Optional[_LogFile]:
         path = self.file_path(timestamp)
         if path.exists():
-            return _LogsFile(path=path, timestamp=timestamp)
+            return _LogFile(path=path, timestamp=timestamp)
         return None
 
-    def find_all(self) -> list[_LogsFile]:
-        files: list[_LogsFile] = []
+    def find_all(self) -> list[_LogFile]:
+        files: list[_LogFile] = []
         # check if the path is directory
         if not self._directory.is_dir():
             return files
@@ -315,7 +315,7 @@ class _LogsDirectory:
                 r"external_link_(?P<timestamp>\d+).json", path.name
             ):
                 files.append(
-                    _LogsFile(
+                    _LogFile(
                         path=path, timestamp=int(filename_match.group("timestamp"))
                     )
                 )
@@ -327,7 +327,7 @@ class _LogsDirectory:
         self,
         *,
         timestamp: Optional[int] = None,
-    ) -> Optional[_LogsFile]:
+    ) -> Optional[_LogFile]:
         return next(
             (
                 file

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -359,6 +359,7 @@ class _LogEditor:
         self._logger = logger
         self._logs: dict[str, ExternalLinkLog] = {}
         self._added_links: dict[str, ExternalLink] = {}
+        self._updated_logs: dict[str, ExternalLinkLog] = {}
         self._deleted_links: set[str] = set()
 
     def load_logs(self, logs: list[ExternalLinkLog]) -> None:
@@ -382,16 +383,18 @@ class _LogEditor:
         self._added_links = added_links
         self._deleted_links = deleted_links
 
-    def add_log(self, log: ExternalLinkLog) -> None:
+    def update_log(self, log: ExternalLinkLog) -> None:
         # delete from added links
-        link = self._added_links.pop(log.url, None)
-        if link is None:
-            self._logger.warning(f"log of non-target URL({log.url}) is added")
+        self._added_links.pop(log.url, None)
         # add to logs
         self._logs[log.url] = log
+        self._updated_logs[log.url] = log
 
     def added_links(self) -> list[ExternalLink]:
         return list(self._added_links.values())
+
+    def updated_logs(self) -> list[ExternalLinkLog]:
+        return list(self._updated_logs.values())
 
     def output(self) -> _Log:
         if self._added_links:
@@ -504,7 +507,7 @@ def _request(
     )
     # add new log
     for log in logs:
-        editor.add_log(log)
+        editor.update_log(log)
     return editor.output()
 
 

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -404,14 +404,16 @@ class _LogEditor:
     def __init__(
         self,
         timestamp: int,
-        logs: list[ExternalLinkLog],
         logger: logging.Logger,
     ) -> None:
         self._timestamp = timestamp
         self._logger = logger
-        self._logs: dict[str, ExternalLinkLog] = {log.url: log for log in logs}
+        self._logs: dict[str, ExternalLinkLog] = {}
         self._added_links: dict[str, ExternalLink] = {}
         self._deleted_links: set[str] = set()
+
+    def load_logs(self, logs: list[ExternalLinkLog]) -> None:
+        self._logs.update({log.url: log for log in logs})
 
     def update_links(self, links: list[ExternalLink]) -> None:
         # match link & log

--- a/backup_cosense/_external_link.py
+++ b/backup_cosense/_external_link.py
@@ -145,7 +145,6 @@ def save_external_links(
 ) -> CommitTarget:
     config = config or ExternalLinkConfig()
     logger = logger or logging.getLogger(__name__)
-    request_all = config.allways_request_all_links
     # session
     if session is None:
         session = _create_session(config)
@@ -158,20 +157,17 @@ def save_external_links(
     )
     # load previous saved list
     previous_saved_list = links_directory.load_file_list()
-    # check previous content_types
-    if previous_saved_list is not None and (
-        set(previous_saved_list.content_types) != set(config.content_types)
-    ):
-        logger.info("request all links because content types are changed")
-        request_all = True
     # load previous log
     previous_logs = (
         log_directory.load_latest(timestamp=backup.timestamp) or []
-        if not request_all
+        if not config.allways_request_all_links
         else []
     )
     # check if log file exists
-    if not request_all and (logs := log_directory.load(backup.timestamp)) is not None:
+    if (
+        not config.allways_request_all_links
+        and (logs := log_directory.load(backup.timestamp)) is not None
+    ):
         # links
         links = _re_request_targets(
             logs,


### PR DESCRIPTION
# Modify save_external_links()

Change arguments from `backup: Backup` to `timestamp: int, links: list[ExternalLink]` to make it easier to test.

Fix #52
- `aiohttp.TCPConnector()` require a running event loop.
- Change the argument from `session` to `create_session: Callable[[], aiohttp.ClientSession]`. 

Disable re-request when content type changes.
Do not load a log with the same timestamp.