### PR TITLE
Use dataclass for option

### DIFF
--- a/backup_cosense/_main.py
+++ b/backup_cosense/_main.py
@@ -63,6 +63,10 @@ class CommonOption:
 
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.set_defaults(cls=cls)
+
+    @classmethod
+    def add_common_arguments(cls, parser: argparse.ArgumentParser) -> None:
         # config
         parser.add_argument(
             "--config",
@@ -84,16 +88,12 @@ class CommonOption:
 
 @dataclasses.dataclass(frozen=True)
 class DownloadOption(CommonOption):
-    @classmethod
-    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
-        parser.set_defaults(cls=cls)
+    pass
 
 
 @dataclasses.dataclass(frozen=True)
 class CommitOption(CommonOption):
-    @classmethod
-    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
-        parser.set_defaults(cls=cls)
+    pass
 
 
 @dataclasses.dataclass(frozen=True)
@@ -103,7 +103,7 @@ class ExportOption(CommonOption):
 
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
-        parser.set_defaults(cls=cls)
+        super().add_arguments(parser)
         # destination
         parser.add_argument(
             "-d",
@@ -136,7 +136,7 @@ def parse_args(args: Optional[list[str]] = None) -> Option:
 def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog=__package__)
     # common
-    CommonOption.add_arguments(parser)
+    CommonOption.add_common_arguments(parser)
     # sub parser
     sub_parsers = parser.add_subparsers(
         title="command",

--- a/backup_cosense/_main.py
+++ b/backup_cosense/_main.py
@@ -47,7 +47,7 @@ def backup_cosense(
     if option.command == "export":
         logger.info("command: export")
         destination = BackupArchive(
-            pathlib.Path(option.destination),
+            option.destination,
             subdirectory=option.subdirectory,
             logger=logger,
         )
@@ -111,6 +111,7 @@ def _add_export_arguments(parser: argparse.ArgumentParser) -> None:
         dest="destination",
         required=True,
         metavar="DIR",
+        type=pathlib.Path,
         help="directory to export backups",
     )
     # subdirectory

--- a/backup_cosense/_main.py
+++ b/backup_cosense/_main.py
@@ -27,7 +27,7 @@ def backup_cosense(
         )
         logger.addHandler(handler)
     # option
-    option = Option(**vars(_argument_parser().parse_args(args=args)))
+    option = parse_args(args)
     if option.verbose:
         logger.setLevel(logging.DEBUG)
     logger.debug(f"option: {option}")
@@ -62,6 +62,12 @@ class Option:
     command: Literal["download", "commit", "export"]
     destination: pathlib.Path
     subdirectory: bool
+
+
+def parse_args(args: Optional[list[str]] = None) -> Option:
+    parser = _argument_parser()
+    option = parser.parse_args(args)
+    return Option(**vars(option))
 
 
 def _argument_parser() -> argparse.ArgumentParser:

--- a/backup_cosense/_main.py
+++ b/backup_cosense/_main.py
@@ -36,11 +36,11 @@ def backup_cosense(
     # main
     logger.info("backup-cosense")
     # download backup
-    if option.command in (None, "download"):
+    if option.command == "download":
         logger.info("command: download")
         download_backups(config, logger=logger)
     # commit
-    if option.command in (None, "commit"):
+    if option.command == "commit":
         logger.info("command: commit")
         commit_backups(config, logger=logger)
     # export
@@ -61,10 +61,8 @@ def _argument_parser() -> argparse.ArgumentParser:
     sub_parsers = parser.add_subparsers(
         dest="command",
         title="command",
-        description=(
-            "command to be executed "
-            "(if not specified, download and commit are executed)"
-        ),
+        description="command to be executed",
+        required=True,
     )
     # download
     sub_parsers.add_parser(

--- a/backup_cosense/_main.py
+++ b/backup_cosense/_main.py
@@ -1,7 +1,8 @@
 import argparse
+import dataclasses
 import logging
 import pathlib
-from typing import Optional
+from typing import Literal, Optional
 
 from ._backup import BackupArchive
 from ._commit import commit_backups
@@ -26,7 +27,7 @@ def backup_cosense(
         )
         logger.addHandler(handler)
     # option
-    option = _argument_parser().parse_args(args=args)
+    option = Option(**vars(_argument_parser().parse_args(args=args)))
     if option.verbose:
         logger.setLevel(logging.DEBUG)
     logger.debug(f"option: {option}")
@@ -52,6 +53,15 @@ def backup_cosense(
             logger=logger,
         )
         export_backups(config, destination, logger=logger)
+
+
+@dataclasses.dataclass(frozen=True)
+class Option:
+    config: pathlib.Path
+    verbose: bool
+    command: Literal["download", "commit", "export"]
+    destination: pathlib.Path
+    subdirectory: bool
 
 
 def _argument_parser() -> argparse.ArgumentParser:

--- a/backup_cosense/_main.py
+++ b/backup_cosense/_main.py
@@ -64,6 +64,32 @@ class Option:
     subdirectory: bool
 
 
+@dataclasses.dataclass(frozen=True)
+class CommonOption:
+    config: pathlib.Path
+    verbose: bool
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        # config
+        parser.add_argument(
+            "--config",
+            dest="config",
+            default="config.toml",
+            metavar="TOML",
+            type=pathlib.Path,
+            help=".toml file (default %(default)s)",
+        )
+        # verbose
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            dest="verbose",
+            action="store_true",
+            help="set log level to debug",
+        )
+
+
 def parse_args(args: Optional[list[str]] = None) -> Option:
     parser = _argument_parser()
     option = parser.parse_args(args)
@@ -72,7 +98,8 @@ def parse_args(args: Optional[list[str]] = None) -> Option:
 
 def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog=__package__)
-    _add_common_arguments(parser)
+    # common
+    CommonOption.add_arguments(parser)
     # sub parser
     sub_parsers = parser.add_subparsers(
         dest="command",
@@ -97,26 +124,6 @@ def _argument_parser() -> argparse.ArgumentParser:
     )
     _add_export_arguments(export_parser)
     return parser
-
-
-def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
-    # config
-    parser.add_argument(
-        "--config",
-        dest="config",
-        default="config.toml",
-        metavar="TOML",
-        type=pathlib.Path,
-        help=".toml file (default %(default)s)",
-    )
-    # verbose
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        help="set log level to debug",
-    )
 
 
 def _add_export_arguments(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
# Use dataclass for option.

Add option classes for each command.

# Require command option

Before the change, download and commit are executed when no command options
are specified

Enable to add options to download and commit commands.